### PR TITLE
preserve original ssh config

### DIFF
--- a/create-instance-using-ubuntu.sh
+++ b/create-instance-using-ubuntu.sh
@@ -15,6 +15,7 @@ instanceId=$(echo -e "$instance_response" |  jq -r '.Instances[] | .InstanceId' 
 PublicIpAddress=$(aws ec2 describe-instances \
     --instance-id $instanceId | jq -r '.Reservations[] | .Instances[] | .PublicIpAddress' | tr -d '"')
 rm -rf config
+sed '/# Created on/,$d' ~/.ssh/config
 cat <<EOF >config
 # Created on $(date)
 Host CloudGenius
@@ -26,7 +27,8 @@ Host CloudGenius
   LocalForward 8080 127.0.0.1:80
   LocalForward 4000 127.0.0.1:4000
 EOF
-mv -f config ~/.ssh/config
+cat config >> ~/.ssh/config
+rm -rf config
 # rm -rf provision.txt
 
 # ssh -o "StrictHostKeyChecking no" CloudGenius "curl -s https://s3-us-west-2.amazonaws.com/cloudgeniuscode/mountdisk.sh | bash"


### PR DESCRIPTION
The current version of [create-instance-using-ubuntu.sh](https://github.com/beacloudgenius/cloudgeniuscode/blob/main/create-instance-using-ubuntu.sh) does not preserve the previous ~/.ssh/config file that the user might have. I have fixed it so that the new Host config is appended and any previous CloudGenius host config lines are deleted, keeping the original file unchanged.